### PR TITLE
Showing list of children pages when the page itself is empty

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
  NODE_TLS_REJECT_UNAUTHORIZED = '0'
  GRIDSOME_CONTACT_FORM_URL = 'https://script.google.com/macros/s/AKfycbw9QbJ_q_ujDTaEWTwImKcqJ0QI5Agw3x7-i7TScZ1QUS080EU/exec'
  GRIDSOME_COMMENT_POST_URL = 'https://hack.bg/wp-json/wp/v2/comments'
+ GRIDSOME_BASE_URL = 'https://hack.bg'

--- a/src/assets/style/_custombootstrap.scss
+++ b/src/assets/style/_custombootstrap.scss
@@ -17,10 +17,10 @@
 //@import "bootstrap/scss/_custom-forms.scss";
 @import 'bootstrap/scss/_nav.scss';
 @import 'bootstrap/scss/_navbar.scss';
-//@import "bootstrap/scss/_card.scss";
+@import "bootstrap/scss/_card.scss";
 //@import "bootstrap/scss/_breadcrumb.scss";
 @import 'bootstrap/scss/_pagination.scss';
-//@import "bootstrap/scss/_badge.scss";
+@import "bootstrap/scss/_badge.scss";
 @import "bootstrap/scss/_jumbotron.scss";
 //@import "bootstrap/scss/_alert.scss";
 @import "bootstrap/scss/_progress.scss";

--- a/src/assets/style/styles.scss
+++ b/src/assets/style/styles.scss
@@ -421,27 +421,6 @@ a.nav-top-a {
   }
 }
 
-.career-card {
-  .card {
-    border: 1px dashed #c318d8;
-  }
-
-  &:hover {
-    text-decoration: none;
-  }
-}
-
-.career-card-footer {
-  border-top: 1px solid #b57ef23d;
-  padding: 0rem 0.25rem;
-  background: none;
-}
-
-.badge-hack-light {
-  color: #9013FE;
-  background-color: #c318d81a;
-}
-
 /* Media Object */
 
 .media {

--- a/src/components/PageChildrenList.vue
+++ b/src/components/PageChildrenList.vue
@@ -1,0 +1,73 @@
+<template>
+  <b-row>
+    <b-col sm="4" v-for="child in children" :key="child.id">
+      <a :href="child.link" class="child-card">
+        <div class="card mb-3" style="max-width: 18rem;">
+          <div class="card-body" style="text-align: left;">
+            <h5 style="margin: 0 auto;">{{child.title}}</h5>
+          </div>
+          <div class="card-footer child-card-footer">
+            <span
+              class="badge badge-hack-light m-1"
+              v-for="tag in child.tags"
+              :key="tag.id"
+            >{{tag.title}}</span>
+          </div>
+        </div>
+      </a>
+    </b-col>
+  </b-row>
+</template>
+
+<static-query>
+    query {
+          children: allWordPressPage {
+    edges {
+      node {
+        title
+        link
+        parent
+        id
+        tags{
+          title
+          id
+        }
+      }
+    }
+  }
+    }
+</static-query>
+
+<script>
+export default {
+  props: {
+    parentId: {
+      type: String,
+      required: true,
+    },
+  },
+  computed: {
+    children() {
+      return this.$static.children.edges
+        .map((c) => c.node)
+        .filter((e) => e.parent.toString() === this.parentId);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.child-card {
+  color: #000000;
+  text-decoration: none;
+}
+
+.card {
+  border: 1px dashed #9013fe;
+}
+
+.badge-hack-light {
+  color: #9013fe;
+  background-color: #c318d81a;
+}
+</style>

--- a/src/components/PageChildrenList.vue
+++ b/src/components/PageChildrenList.vue
@@ -1,7 +1,7 @@
 <template>
   <b-row>
     <b-col sm="4" v-for="child in children" :key="child.id">
-      <a :href="child.link" class="child-card">
+      <a :href="child.link.replace(baseUrl, '')" class="child-card">
         <div class="card mb-3" style="max-width: 18rem;">
           <div class="card-body" style="text-align: left;">
             <h5 style="margin: 0 auto;">{{child.title}}</h5>
@@ -45,6 +45,11 @@ export default {
       type: String,
       required: true,
     },
+  },
+  data() {
+    return {
+      baseUrl: process.env.GRIDSOME_BASE_URL,
+    };
   },
   computed: {
     children() {

--- a/src/plugins/wp-source/index.js
+++ b/src/plugins/wp-source/index.js
@@ -53,12 +53,12 @@ class WordPressSource {
 
       console.log(`Loading data from ${baseUrl}`);
 
-      await this.getPostTypes(store)
-      await this.getUsers(store)
-      await this.getTaxonomies(store)
-      await this.getPosts(store)
-      await this.getComments(store)
-      this.createPages(api)
+      await this.getPostTypes(store);
+      await this.getUsers(store);
+      await this.getTaxonomies(store);
+      await this.getPosts(store);
+      await this.getComments(store);
+      this.createPages(api);
     })
   }
 
@@ -340,8 +340,8 @@ function ensureArrayData(url, data) {
     } catch (err) {
       throw new Error(
         `Failed to fetch ${url}\n` +
-          `Expected JSON response but received:\n` +
-          `${data.trim().substring(0, 150)}...\n`,
+        `Expected JSON response but received:\n` +
+        `${data.trim().substring(0, 150)}...\n`,
       );
     }
   }

--- a/src/templates/WordPressPage.vue
+++ b/src/templates/WordPressPage.vue
@@ -3,9 +3,10 @@
     <b-row class="align-items-start">
       <transition name="fade" appear>
         <b-col tag="main" cols="12" lg="12" class="bg-white p-0 rounded shadow-lg">
-          <div class="overflow-hidden p-4 p-sm-5 ">
+          <div class="overflow-hidden p-4 p-sm-5">
             <h1 class="mb-5">{{ $page.page.title }}</h1>
             <div class="page-content" v-html="$page.page.content" />
+            <PageChildrenList v-if="!$page.page.content" :parentId="$page.page.id" />
           </div>
         </b-col>
       </transition>
@@ -18,16 +19,20 @@ query($path: String) {
   page: wordPressPage(path: $path) {
     title
     content
+    id
   }
 }
 </page-query>
 
 <script>
+import PageChildrenList from "~/components/PageChildrenList.vue";
+
 export default {
+  components: { PageChildrenList },
   metaInfo() {
     return {
       title: this.$page.page.title,
-    }
+    };
   },
-}
+};
 </script>


### PR DESCRIPTION
fix #46 

![image](https://user-images.githubusercontent.com/47859124/91312407-e3352400-e7bc-11ea-9304-a31d5045a886.png)

The careers page is empty in the api, so there's some kind of a workaround displaying a list of page's children