### PR TITLE
Disallow only google bot from crawling

### DIFF
--- a/scripts/before-deploy.sh
+++ b/scripts/before-deploy.sh
@@ -6,4 +6,4 @@ if [[ $CNAME != "" ]]; then
 fi
 
 # add robots txt - prevent crawling
-echo $'User-agent: *\nDisallow: /' > dist/robots.txt
+echo $'User-agent: GoogleBot\nDisallow: /' > dist/robots.txt


### PR DESCRIPTION
This change should make the `robots.txt` disallow crawling the page only by GoogleBot, and let other spiders and indexing bots to be able to crawl the page.

The content of the `robots.txt` after this change should be looking like:

```
User-agent: GoogleBot
Disallow: /
```