### PR TITLE
Fix decodeURIComponent error

### DIFF
--- a/src/plugins/wp-source/index.js
+++ b/src/plugins/wp-source/index.js
@@ -325,7 +325,8 @@ class WordPressSource {
       return this.normalizeFields(value);
     }
 
-    return value;
+    //ensures decodeURIComponent won't fail
+    return typeof value ==='string' ? value.replace(/%(?![0-9][0-9a-fA-F]+)/g, '%25'): value;
   }
 
   createTypeName(name = '') {


### PR DESCRIPTION
Bad URI encoding format of "rank_math_schema_Article" field in "metadata" throwed error when trying to normalize value.
This fix ensures '%' symbols are properly formatted.