### PR TITLE
Add author section

### DIFF
--- a/src/components/AuthorSection.vue
+++ b/src/components/AuthorSection.vue
@@ -1,0 +1,50 @@
+<template>
+    <b-row class="author-section my-5">
+        <div class="media-body">
+            <p>About the author</p>
+            <h3>
+                <g-link :to="author.path" class="font-weight-bold" :title="`Posts by ${author.name}`">
+                    {{ author.name }}
+                </g-link>
+            </h3>
+            <h5></h5>
+            <p>
+                {{author.description}}
+            </p>
+            <div class="author-icons">
+                <a href="" class="author-twitter" target="_blank">
+                    <i class="fab fa-twitter" />
+                    Twitter
+                </a>
+                <a href="" class="author-linkedin" target="_blank">
+                    <i class="fab fa-linkedin" />
+                    LinkedIn
+                </a>
+            </div>
+        </div>
+        <div class="media-figure avatar-clipping-mask">
+            <img :src="author.avatars.avatar96" width="200" height="200" alt="Silvia Chitakova" class="avatar avatar-200 wp-user-avatar wp-user-avatar-200 alignnone photo">
+        </div>
+    </b-row>
+</template>
+
+<script>
+export default {
+    props: {
+        author: {
+            type: Object,
+            required: true,
+        },
+    },
+}
+</script>
+
+<style scoped>
+.author-section {
+    background: #f7f7f7;
+    padding: 20px;
+    border-radius: 2px;
+    display: flex;
+    align-items: flex-start;
+}
+</style>

--- a/src/templates/WordPressPost.vue
+++ b/src/templates/WordPressPost.vue
@@ -68,6 +68,7 @@
         </b-col>
       </transition>
     </b-row>
+    <AuthorSection :author="$page.post.author" />
     <NewsletterForm />
     <CommentSection :post="$page.post.id" />
   </Layout>
@@ -107,6 +108,10 @@ query Post($path: String!) {
     author {
       name
       path
+      description
+      avatars {
+        avatar96
+      }
     }
     metadata {
       postAudioId
@@ -124,14 +129,15 @@ query Post($path: String!) {
 import Post from '~/components/Post.vue';
 import NewsletterForm from '~/components/NewsletterForm.vue';
 import CommentSection from '~/components/CommentSection.vue';
+import AuthorSection from '~/components/AuthorSection.vue';
 
 export default {
   components: {
     Post,
     NewsletterForm,
     CommentSection,
+    AuthorSection
   },
-  mounted() {},
   metaInfo() {
     const metaDescription = this.$page.post.metadata
       ? [


### PR DESCRIPTION
In order all of the author information is displayed (job title, social media links, higher quality picture) the metadata of the users should be exposed.

References:
https://stackoverflow.com/questions/37641689/wp-rest-api-get-posts-with-their-meta
https://wordpress.stackexchange.com/questions/270154/getting-user-meta-data-from-wp-rest-api